### PR TITLE
Updater Improvements

### DIFF
--- a/app/driveshare.html
+++ b/app/driveshare.html
@@ -173,7 +173,7 @@
           <h4 v-if="!update" class="modal-title">No Update Available</h4>
         </div>
         <div v-if="!update" class="modal-body">You are already using the latest version.</div>
-        <div v-if="update" class="modal-body">There is an update available, would you like to download the update now?</div>
+        <div v-if="update" class="modal-body">DriveShare {{releaseTag}} is available! Would you like to download the update now?</div>
         <div class="modal-footer">
           <button v-if="!update" type="button" class="btn btn-blue" data-dismiss="modal">Close</button>
           <div v-if="update" class="btn-group">

--- a/app/lib/views.js
+++ b/app/lib/views.js
@@ -143,7 +143,9 @@ var about = new Vue({
 var updater = new Vue({
   el: '#updater',
   data: {
-    update: false
+    update: false,
+    releaseURL: '',
+    releaseTag: ''
   },
   methods: {
     download: function(event) {
@@ -151,7 +153,7 @@ var updater = new Vue({
         event.preventDefault();
       }
 
-      shell.openExternal('https://github.com/Storj/driveshare-gui/releases');
+      shell.openExternal(this.releaseURL);
     }
   },
   created: function() {
@@ -160,17 +162,16 @@ var updater = new Vue({
 
     ipc.on('checkForUpdates', function() {
       updater.check();
+      $('#updater').modal('show');
     });
 
     updater.check();
 
-    updater.on('update_available', function() {
+    updater.on('update_available', function(meta) {
       view.update = true;
+      view.releaseTag = meta.releaseTag;
+      view.releaseURL = meta.releaseURL;
 
-      $('#updater').modal('show');
-    });
-
-    ipc.on('checkForUpdates', function() {
       $('#updater').modal('show');
     });
   }

--- a/app/package.json
+++ b/app/package.json
@@ -8,7 +8,7 @@
   "main": "main.js",
   "config": {
     "target": "development",
-    "versionCheckURL": "https://raw.githubusercontent.com/Storj/driveshare-gui/master/app/package.json"
+    "versionCheckURL": "https://api.github.com/repos/Storj/driveshare-gui/releases"
   },
   "dependencies": {
     "adm-zip": "^0.4.7",
@@ -17,10 +17,11 @@
     "diskspace": "keverw/diskspace.js",
     "electron-safe-ipc": "^0.6.1",
     "fs-extra": "^0.24.0",
-    "fs-jetpack": "^0.7.0",
     "jquery": "^2.1.4",
     "request": "^2.63.0",
     "semver": "^5.1.0",
     "vue": "^1.0.10"
-  }
+  },
+  "license": "MIT",
+  "repository": "https://github.com/storj/driveshare-gui"
 }

--- a/app/test/unit/updater.unit.js
+++ b/app/test/unit/updater.unit.js
@@ -69,9 +69,9 @@ describe('Updater', function() {
     it('should not emit if version not greater than current', function(done) {
       var Updater = proxyquire('../../lib/updater', {
         request: function(url, callback) {
-          callback(null, { statusCode: 200 }, JSON.stringify({
-            version: '0.0.0'
-          }));
+          callback(null, { statusCode: 200 }, [
+            { html_url: '', tag_name: '0.0.0' }
+          ]);
         }
       });
       var updater = new Updater();
@@ -85,13 +85,15 @@ describe('Updater', function() {
     it('should emit if the version is greater than current', function(done) {
       var Updater = proxyquire('../../lib/updater', {
         request: function(url, callback) {
-          callback(null, { statusCode: 200 }, JSON.stringify({
-            version: '100.0.0'
-          }));
+          callback(null, { statusCode: 200 }, [
+            { html_url: '', tag_name: '100.0.0' }
+          ]);
         }
       });
       var updater = new Updater();
-      updater.once('update_available', done);
+      updater.once('update_available', function(meta) {
+        done();
+      });
       updater.check();
     });
 


### PR DESCRIPTION
Instead of fetching and parsing the `app/package.json` file in the `master` branch, we now use the GitHub API to fetch the repository's releases. This ensures that users do not get update notifications before releases are properly tagged, bundled, and published.

Closes #90 