### PR TITLE
Check for Dataserv-Client Updates

### DIFF
--- a/app/client.js
+++ b/app/client.js
@@ -194,6 +194,10 @@ var updater = new Vue({
 
       $('#updater').modal('show');
     });
+
+    updater.on('error', function(err) {
+      console.log(err);
+    });
   }
 });
 

--- a/app/lib/dataserv.js
+++ b/app/lib/dataserv.js
@@ -149,7 +149,7 @@ DataServWrapper.prototype.validateClient = function(execname, callback) {
       return callback(new Error('Invalid dataserv-client'));
     }
 
-    callback(null);
+    callback(null, stdout);
   });
 };
 

--- a/app/lib/installer.js
+++ b/app/lib/installer.js
@@ -305,7 +305,6 @@ DataServInstaller.prototype._downloadAndExtract = function(callback) {
  */
 DataServInstaller.prototype._needsDataservUpdate = function(dspath, callback) {
   var self = this;
-  var versionCheck = spawn(dspath, ['version']);
 
   execFile(dspath, ['version'], function(err, version) {
     if (err) {
@@ -319,8 +318,6 @@ DataServInstaller.prototype._needsDataservUpdate = function(dspath, callback) {
 
       callback(null, semver.gt(remoteVersion, version));
     });
-
-    versionCheck.kill();
   });
 };
 

--- a/app/lib/installer.js
+++ b/app/lib/installer.js
@@ -302,10 +302,10 @@ DataServInstaller.prototype._downloadAndExtract = function(callback) {
  * #_checkDataservVersion
  * @param {String}
  */
-DataServInstaller.prototype._needsDataservUpdate = function(path, callback) {
+DataServInstaller.prototype._needsDataservUpdate = function(dspath, callback) {
   var self = this;
-  var cwd = path.dirname(path);
-  var program = path.basename(path);
+  var cwd = path.dirname(dspath);
+  var program = path.basename(dspath);
 
   exec(program + ' version', { cwd: cwd }, function(err, version) {
     if (err) {

--- a/app/lib/installer.js
+++ b/app/lib/installer.js
@@ -304,8 +304,10 @@ DataServInstaller.prototype._downloadAndExtract = function(callback) {
  */
 DataServInstaller.prototype._needsDataservUpdate = function(path, callback) {
   var self = this;
+  var cwd = path.dirname(path);
+  var program = path.basename(path);
 
-  exec(path.split(' ').join('\ ') + ' version', function(err, version) {
+  exec(program + ' version', { cwd: cwd }, function(err, version) {
     if (err) {
       return callback(err);
     }

--- a/app/lib/installer.js
+++ b/app/lib/installer.js
@@ -315,11 +315,12 @@ DataServInstaller.prototype._needsDataservUpdate = function(dspath, callback) {
 
       callback(null, semver.gt(remoteVersion, version));
     });
+
     versionCheck.kill();
   });
 
   versionCheck.on('error', function(err) {
-    return callback(err);
+    return callback(null, true);
   });
 };
 

--- a/app/lib/installer.js
+++ b/app/lib/installer.js
@@ -10,8 +10,7 @@ var inherits = require('util').inherits;
 var os = require('os');
 var Logger = require('./logger');
 var child_process = require('child_process');
-var exec = child_process.exec;
-var execFile = child_process.execFile;
+var exec = require('child_process').exec;
 var request = require('request');
 var fs = require('fs-extra');
 var ZipFile = require('adm-zip');
@@ -306,7 +305,7 @@ DataServInstaller.prototype._downloadAndExtract = function(callback) {
 DataServInstaller.prototype._needsDataservUpdate = function(path, callback) {
   var self = this;
 
-  execFile(path, ['version'], function(err, version) {
+  exec(path.split(' ').join('\ ') + ' version', function(err, version) {
     if (err) {
       return callback(err);
     }

--- a/app/lib/installer.js
+++ b/app/lib/installer.js
@@ -11,7 +11,6 @@ var os = require('os');
 var Logger = require('./logger');
 var child_process = require('child_process');
 var exec = child_process.exec;
-var execFile = child_process.execFile;
 var request = require('request');
 var fs = require('fs-extra');
 var ZipFile = require('adm-zip');
@@ -306,7 +305,7 @@ DataServInstaller.prototype._downloadAndExtract = function(callback) {
 DataServInstaller.prototype._needsDataservUpdate = function(dspath, callback) {
   var self = this;
 
-  execFile(dspath, ['version'], function(err, version) {
+  exec('"' + dspath + '" version', function(err, version) {
     if (err) {
       return callback(null, true);
     }

--- a/app/lib/installer.js
+++ b/app/lib/installer.js
@@ -9,7 +9,9 @@ var EventEmitter = require('events').EventEmitter;
 var inherits = require('util').inherits;
 var os = require('os');
 var Logger = require('./logger');
-var exec = require('child_process').exec;
+var child_process = require('child_process');
+var exec = child_process.exec;
+var execFile = child_process.execFile;
 var request = require('request');
 var fs = require('fs-extra');
 var ZipFile = require('adm-zip');
@@ -304,7 +306,7 @@ DataServInstaller.prototype._downloadAndExtract = function(callback) {
 DataServInstaller.prototype._needsDataservUpdate = function(path, callback) {
   var self = this;
 
-  exec(path + ' version', function(err, version) {
+  execFile(path + ' version', function(err, version) {
     if (err) {
       return callback(err);
     }

--- a/app/lib/installer.js
+++ b/app/lib/installer.js
@@ -11,7 +11,7 @@ var os = require('os');
 var Logger = require('./logger');
 var child_process = require('child_process');
 var exec = child_process.exec;
-var spawn = child_process.spawn;
+var execFile = child_process.execFile;
 var request = require('request');
 var fs = require('fs-extra');
 var ZipFile = require('adm-zip');
@@ -307,7 +307,11 @@ DataServInstaller.prototype._needsDataservUpdate = function(dspath, callback) {
   var self = this;
   var versionCheck = spawn(dspath, ['version']);
 
-  versionCheck.stdout.on('data', function(version) {
+  execFile(dspath, ['version'], function(err, version) {
+    if (err) {
+      return callback(null, true);
+    }
+
     self._getLatestDataservRelease(function(err, remoteVersion) {
       if (err) {
         return callback(err);
@@ -317,10 +321,6 @@ DataServInstaller.prototype._needsDataservUpdate = function(dspath, callback) {
     });
 
     versionCheck.kill();
-  });
-
-  versionCheck.on('error', function(err) {
-    return callback(null, true);
   });
 };
 

--- a/app/lib/installer.js
+++ b/app/lib/installer.js
@@ -306,7 +306,7 @@ DataServInstaller.prototype._downloadAndExtract = function(callback) {
 DataServInstaller.prototype._needsDataservUpdate = function(path, callback) {
   var self = this;
 
-  execFile(path + ' version', function(err, version) {
+  execFile(path, ['version'], function(err, version) {
     if (err) {
       return callback(err);
     }

--- a/app/package.json
+++ b/app/package.json
@@ -8,7 +8,8 @@
   "main": "main.js",
   "config": {
     "target": "development",
-    "versionCheckURL": "https://api.github.com/repos/Storj/driveshare-gui/releases"
+    "versionCheckURL": "https://api.github.com/repos/Storj/driveshare-gui/releases",
+    "dataservCheckURL": "https://api.github.com/repos/Storj/dataserv-client/releases"
   },
   "dependencies": {
     "adm-zip": "^0.4.7",

--- a/app/test/unit/installer.unit.js
+++ b/app/test/unit/installer.unit.js
@@ -641,6 +641,7 @@ describe('DataServInstaller', function() {
       ).callsArgWith(0, new Error('Failed'));
       installer._needsDataservUpdate('', function(err) {
         expect(err.message).to.equal('Failed');
+        _getLatestDataservRelease.restore();
         done();
       });
     });
@@ -658,6 +659,7 @@ describe('DataServInstaller', function() {
       ).callsArgWith(0, null, '1000.0.0');
       installer._needsDataservUpdate('', function(err, needsUpdate) {
         expect(needsUpdate).to.equal(true);
+        _getLatestDataservRelease.restore();
         done();
       });
     });


### PR DESCRIPTION
Closes #96 

Tested on Windows and OSX - GNU/Linux dependencies are handled by `APT`.

> Note: I could not even get the older 32 bit OSX binary to run at all. If this happens (during version check), the user will likely get an error message from OSX stating that the command failed. After dismissal, everything behaves as expected and updates the dataserv-client.

