### PR TITLE
Enforce JSHint Rules in Test Runner (and Travis CI)

### DIFF
--- a/app/lib/dataserv.js
+++ b/app/lib/dataserv.js
@@ -4,7 +4,6 @@
 
 'use strict';
 
-var os = require('os');
 var child_process = require('child_process');
 var exec = child_process.execFile;
 var spawn = child_process.spawn;
@@ -140,7 +139,7 @@ DataServWrapper.prototype.setAddress = function(address, id, callback) {
  * @param {Function} callback
  */
 DataServWrapper.prototype.validateClient = function(execname, callback) {
-  exec(execname, ['version'], function(err, stdout, stderr) {
+  exec(execname, ['version'], function(err, stdout) {
     if (err) {
       return callback(err);
     }

--- a/app/test/unit/updater.unit.js
+++ b/app/test/unit/updater.unit.js
@@ -91,7 +91,7 @@ describe('Updater', function() {
         }
       });
       var updater = new Updater();
-      updater.once('update_available', function(meta) {
+      updater.once('update_available', function() {
         done();
       });
       updater.check();

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "gulp-sourcemaps": "^1.5.2",
     "gulp-util": "^3.0.6",
     "istanbul": "^0.4.1",
+    "jshint": "^2.8.0",
     "mocha": "^2.3.4",
     "proxyquire": "^1.7.3",
     "q": "^1.4.1",
@@ -29,8 +30,9 @@
     "build": "./node_modules/.bin/gulp build",
     "release": "./node_modules/.bin/gulp release --env=production",
     "start": "node ./tasks/start",
-    "test": "npm run test-unit",
+    "test": "npm run test-unit && npm run jshint",
     "test-unit": "./node_modules/.bin/mocha ./app/test/unit/**",
-    "coverage": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha ./app/test/unit/** -- --recursive"
+    "coverage": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha ./app/test/unit/** -- --recursive",
+    "jshint": "./node_modules/.bin/jshint --config .jshintrc --exclude ./app/node_modules ./app"
   }
 }


### PR DESCRIPTION
This PR makes use of the `.jshintrc` file included in the repository by running JSHint as part of the test runner.

You can run the linter by itsellf with:

```
npm run jshint
```

Otherwise it will run after your tests on:

```
npm test
```