### PR TITLE
Fix #57

### DIFF
--- a/app/css/style.css
+++ b/app/css/style.css
@@ -365,3 +365,12 @@ footer a:hover {
   color:#333;
   white-space:nowrap
 }
+
+.fat32-wrapper {
+  font-size: 12px;
+}
+
+.fat32-check {
+  margin-top: 8px !important;
+  display: inline-block;
+}

--- a/app/driveshare.html
+++ b/app/driveshare.html
@@ -88,11 +88,16 @@
                 <div class="row">
                   <div class="form-group col-xs-12">
                     <label class="control-label" for="storage">Storage Size</label>
+                    <div class="pull-right fat32-wrapper">
+                      <label class="checkbox-inline">
+                        <input class="fat32-check" type="checkbox" v-model="userdata.tabs[current].storage.tree" v-bind:disabled="userdata.tabs[current]._process"> Drive is formatted FAT32
+                      </label>
+                    </div>
                     <div class="row">
-                      <div class="col-xs-8">
+                      <div class="col-xs-6">
                         <input class="form-control size" min="0" name="storage" v-bind:disabled="userdata.tabs[current]._process" placeholder="Set amount of space to share" type="number", v-model="userdata.tabs[current].storage.size">
                       </div>
-                      <div class="col-xs-4">
+                      <div class="col-xs-6">
                       	<select class="form-control size-unit" v-model="userdata.tabs[current].storage.unit" v-bind:disabled="userdata.tabs[current]._process">
                           <option>MB</option>
                           <option>GB</option>

--- a/app/lib/dataserv.js
+++ b/app/lib/dataserv.js
@@ -67,12 +67,17 @@ DataServWrapper.prototype._bootstrap = function(id, name, args) {
  * @param {Object} tab
  */
 DataServWrapper.prototype.farm = function(tab) {
-  return this._bootstrap(tab.id, 'FARMING', [
+  var args = [
     '--config_path=' + this._getConfigPath(tab.id),
     '--store_path=' + tab.storage.path,
-    '--max_size=' + tab.storage.size + tab.storage.unit,
-    'farm'
-  ]);
+    '--max_size=' + tab.storage.size + tab.storage.unit
+  ];
+
+  if (tab.storage.tree) {
+    args.push('--use_folder_tree');
+  }
+
+  return this._bootstrap(tab.id, 'FARMING', args.concat(['farm']));
 };
 
 /**
@@ -81,12 +86,17 @@ DataServWrapper.prototype.farm = function(tab) {
  * @param {Object} tab
  */
 DataServWrapper.prototype.build = function(tab) {
-  return this._bootstrap(tab.id, 'BUILDING', [
+  var args = [
     '--config_path=' + this._getConfigPath(tab.id),
     '--store_path=' + tab.storage.path,
-    '--max_size=' + tab.storage.size + tab.storage.unit,
-    'build'
-  ]);
+    '--max_size=' + tab.storage.size + tab.storage.unit
+  ];
+
+  if (tab.storage.tree) {
+    args.push('--use_folder_tree');
+  }
+
+  return this._bootstrap(tab.id, 'BUILDING', args.concat(['build']));
 };
 
 /**

--- a/app/lib/tab.js
+++ b/app/lib/tab.js
@@ -24,7 +24,8 @@ function Tab(addr, storage, id, active) {
   this.storage = {
     path: storage.path || '',
     size: storage.size || 0,
-    unit: storage.unit || 'GB'
+    unit: storage.unit || 'GB',
+    tree: storage.tree || false
   };
   this.id = id || this.createID();
   this.active = typeof active === 'undefined' ? false : active;

--- a/app/test/unit/dataserv.unit.js
+++ b/app/test/unit/dataserv.unit.js
@@ -93,6 +93,28 @@ describe('DataServWrapper', function() {
       expect(fakeproc._logger._output).to.equal(expected);
     });
 
+    it('should use the folder tree option', function() {
+      var DataServWrapper = proxyquire('../../lib/dataserv', {
+        child_process: {
+          spawn: function() {
+            return {
+              stdout: new EventEmitter(),
+              stderr: new EventEmitter(),
+              kill: sinon.stub()
+            };
+          }
+        }
+      });
+      var dataserv = new DataServWrapper(os.tmpdir(), fakeipc);
+      var tab = new Tab();
+      tab.storage.tree = true;
+      var fakeproc = dataserv.farm(tab);
+      var expected = dataserv._exec + ' --config_path=' + dataserv._datadir +
+                     '/drives/' + tab.id + ' --store_path= --max_size=0GB ' +
+                     '--use_folder_tree farm\n';
+      expect(fakeproc._logger._output).to.equal(expected);
+    });
+
   });
 
   describe('#build', function() {
@@ -115,6 +137,28 @@ describe('DataServWrapper', function() {
       var expected = dataserv._exec + ' --config_path=' + dataserv._datadir +
                      '/drives/' + tab.id + ' --store_path= --max_size=0GB ' +
                      'build\n';
+      expect(fakeproc._logger._output).to.equal(expected);
+    });
+
+    it('should use the folder tree option', function() {
+      var DataServWrapper = proxyquire('../../lib/dataserv', {
+        child_process: {
+          spawn: function() {
+            return {
+              stdout: new EventEmitter(),
+              stderr: new EventEmitter(),
+              kill: sinon.stub()
+            };
+          }
+        }
+      });
+      var dataserv = new DataServWrapper(os.tmpdir(), fakeipc);
+      var tab = new Tab();
+      tab.storage.tree = true;
+      var fakeproc = dataserv.build(tab);
+      var expected = dataserv._exec + ' --config_path=' + dataserv._datadir +
+                     '/drives/' + tab.id + ' --store_path= --max_size=0GB ' +
+                     '--use_folder_tree build\n';
       expect(fakeproc._logger._output).to.equal(expected);
     });
 


### PR DESCRIPTION
This PR adds a checkbox to indicate that the selected drive is formatted FAT32 and will pass the `--use_folder_tree` option to `dataserv-client` accordingly.