### PR TITLE
Fix Settings Corruption

### DIFF
--- a/app/lib/userdata.js
+++ b/app/lib/userdata.js
@@ -200,9 +200,15 @@ UserData.prototype.getBalance = function(address, callback) {
  * @param {Function} callback
  */
 UserData.prototype.saveConfig = function(callback) {
-  fs.writeFile(this._path, JSON.stringify(this.toObject(), null, 2), callback);
+  fs.writeFileSync(this._path, JSON.stringify(this.toObject(), null, 2));
+  callback();
 };
 
+/**
+ * Save the configuration at the given index
+ * #toObject
+ * @returns {Object}
+ */
 UserData.prototype.toObject = function(){
   return {
     tabs: this._parsed.tabs.map(function(tab) {

--- a/app/lib/userdata.js
+++ b/app/lib/userdata.js
@@ -200,7 +200,12 @@ UserData.prototype.getBalance = function(address, callback) {
  * @param {Function} callback
  */
 UserData.prototype.saveConfig = function(callback) {
-  fs.writeFileSync(this._path, JSON.stringify(this.toObject(), null, 2));
+  try {
+    fs.writeFileSync(this._path, JSON.stringify(this.toObject(), null, 2));
+  } catch (err) {
+    return callback(err);
+  }
+  
   callback();
 };
 

--- a/app/test/unit/userdata.unit.js
+++ b/app/test/unit/userdata.unit.js
@@ -313,12 +313,12 @@ describe('UserData', function() {
       var _readFileSync = function() {
         return JSON.stringify({ tabs: [] });
       };
-      var _writeFile = sinon.stub().callsArg(2);
+      var _writeFile = sinon.stub();
       var UserData = proxyquire('../../lib/userdata', {
         fs: {
           existsSync: _existsSync,
           readFileSync: _readFileSync,
-          writeFile: _writeFile
+          writeFileSync: _writeFile
         }
       });
       var userdata = new UserData(os.tmpdir());

--- a/app/test/unit/userdata.unit.js
+++ b/app/test/unit/userdata.unit.js
@@ -330,6 +330,21 @@ describe('UserData', function() {
       });
     });
 
+    it('should pass error from fs.writeFileSync to callback', function(done) {
+      var UserData = proxyquire('../../lib/userdata', {
+        fs: {
+          existsSync: sinon.stub().returns(true),
+          readFileSync: sinon.stub().returns(JSON.stringify({ tabs: [] })),
+          writeFileSync: sinon.stub().throws(new Error('Write Error'))
+        }
+      });
+      var userdata = new UserData(os.tmpdir());
+      userdata.saveConfig(function(err) {
+        expect(err.message).to.equal('Write Error');
+        done();
+      });
+    });
+
   });
 
 });


### PR DESCRIPTION
This PR ensures that disk writes to the settings.json file are synchronous, preventing other writes from occurring in parallel which can lead to a corrupted settings file.

Should fix #183 and #181 

@MrFancyMonocle - review/test/merge?